### PR TITLE
fix: resolve S3 backend DNS at runtime instead of at config load

### DIFF
--- a/default.conf.template
+++ b/default.conf.template
@@ -36,6 +36,13 @@ server {
     listen  8080;
     include /etc/nginx/conf.d/gateway/server_variables.conf;
 
+    # Force per-request runtime DNS resolution of the S3 backend so IP changes
+    # are picked up without an nginx reload. Using a variable in proxy_pass
+    # makes nginx resolve via the resolver (declared at http scope in
+    # upstreams.conf.template) instead of freezing the IP at config load, which
+    # is what a static upstream server does. Cache lifetime follows the DNS TTL.
+    set $s3_backend "${S3_SERVER}:${S3_SERVER_PORT}";
+
     # Don't display the NGINX version number because we don't want to reveal
     # information that could be used to find an exploit.
     server_tokens off;
@@ -145,7 +152,7 @@ server {
 
         error_page 404 @trailslashControl;
 
-        proxy_pass ${S3_SERVER_PROTO}://storage_urls$s3uri;
+        proxy_pass ${S3_SERVER_PROTO}://$s3_backend$s3uri;
 
         include /etc/nginx/conf.d/gateway/s3_location.conf;
     }
@@ -265,7 +272,7 @@ server {
         # Comment out this line to receive the error messages returned by S3
         error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 =404 @error404;
 
-        proxy_pass  ${S3_SERVER_PROTO}://storage_urls$s3Uri;
+        proxy_pass  ${S3_SERVER_PROTO}://$s3_backend$s3Uri;
         include /etc/nginx/conf.d/gateway/s3listing_location.conf;
     }
 
@@ -314,7 +321,7 @@ server {
         # Comment out this line to receive the error messages returned by S3
         error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 =404 @error404;
 
-        proxy_pass  ${S3_SERVER_PROTO}://storage_urls$s3uri;
+        proxy_pass  ${S3_SERVER_PROTO}://$s3_backend$s3uri;
         include /etc/nginx/conf.d/gateway/s3listing_location.conf;
     }
 

--- a/helm/config/default.conf.template
+++ b/helm/config/default.conf.template
@@ -36,6 +36,13 @@ server {
     listen  8080;
     include /etc/nginx/conf.d/gateway/server_variables.conf;
 
+    # Force per-request runtime DNS resolution of the S3 backend so IP changes
+    # are picked up without an nginx reload. Using a variable in proxy_pass
+    # makes nginx resolve via the resolver (declared at http scope in
+    # upstreams.conf.template) instead of freezing the IP at config load, which
+    # is what a static upstream server does. Cache lifetime follows the DNS TTL.
+    set $s3_backend "${S3_SERVER}:${S3_SERVER_PORT}";
+
     # Don't display the NGINX version number because we don't want to reveal
     # information that could be used to find an exploit.
     server_tokens off;
@@ -167,7 +174,7 @@ server {
 
         error_page 404 @trailslashControl;
 
-        proxy_pass ${S3_SERVER_PROTO}://storage_urls$s3uri;
+        proxy_pass ${S3_SERVER_PROTO}://$s3_backend$s3uri;
 
         include /etc/nginx/conf.d/gateway/s3_location.conf;
     }
@@ -288,7 +295,7 @@ server {
         # Comment out this line to receive the error messages returned by S3
         error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 =404 @error404;
 
-        proxy_pass  ${S3_SERVER_PROTO}://storage_urls$s3Uri;
+        proxy_pass  ${S3_SERVER_PROTO}://$s3_backend$s3Uri;
         include /etc/nginx/conf.d/gateway/s3listing_location.conf;
     }
 
@@ -337,7 +344,7 @@ server {
         # Comment out this line to receive the error messages returned by S3
         error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 =404 @error404;
 
-        proxy_pass  ${S3_SERVER_PROTO}://storage_urls$s3uri;
+        proxy_pass  ${S3_SERVER_PROTO}://$s3_backend$s3uri;
         include /etc/nginx/conf.d/gateway/s3listing_location.conf;
     }
 


### PR DESCRIPTION
nginx OSS resolves the hostname in an upstream `server` directive once at config load and caches the IP for the whole worker lifetime. When the S3 DNS record's IP changed behind the gateway, nginx kept connecting to the stale IP, causing connection timeouts and 504s until a reload/restart.

Replace the static `storage_urls` upstream reference in proxy_pass with a `$s3_backend` variable. A variable in proxy_pass forces per-request resolution via the http-scope resolver (DNS_RESOLVERS), so IP changes are picked up without an nginx reload. Cache lifetime follows the DNS TTL.

Applied to both default.conf.template and helm/config/default.conf.template. No upstream keepalive existed before, so no connection-pooling regression.